### PR TITLE
Fix potential bounds exception in Smeltery.

### DIFF
--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -561,7 +561,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
 
     private void updateTemperatures ()
     {
-        for (int i = 0; i < maxBlockCapacity; i++)
+        for (int i = 0; i < maxBlockCapacity && i < meltingTemps.length; i++)
         {
             meltingTemps[i] = Smeltery.getLiquifyTemperature(inventory[i]) * 10; // temperatures are *10 for more progress control
         }


### PR DESCRIPTION
While playing around with trying to find the max row size of a smeltery I ran into this nice bug. Desync between capacity number and temps array.
Start out with this setup:
![Screenshot](http://puu.sh/icShZ/041dc26b52.jpg)
underneth the seared brick is more seared brick to be a valid base
Then start digging out the trough to make the smeltery wider.
If anything falls in and updates you'll get a crash and the world won't be loadable anymore.
This little check allows for the smeltery to recover itself.
